### PR TITLE
Better template for guard init sass

### DIFF
--- a/lib/guard/sass/templates/Guardfile
+++ b/lib/guard/sass/templates/Guardfile
@@ -1,5 +1,3 @@
-guard 'sass' do
-  watch('^sass/(.*)')
-  # watch('^_sass/(.*)')
-  # watch('^scss/(.*))
+guard 'sass', :output => 'public/css' do
+  watch(%r{^sass/.+\.(sass|scss)})
 end


### PR DESCRIPTION
Guard complains if you use a string instead of a regex and I just threw in scss|sass to watch both file extensions by default
