### PR TITLE
Add pre-declaration of `Guard::Guard` to fix bundler error.

### DIFF
--- a/lib/guard/sass/version.rb
+++ b/lib/guard/sass/version.rb
@@ -1,5 +1,8 @@
 module Guard
-  class Sass
+  class Guard
+  end
+
+  class Sass < Guard
     VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
Because of the load order when using a local folder with Bundler the `lib/sass/version.rb` file gets loaded first.  This later causes an error when `Guard::Sass` is redeclared to be a subclass of `Guard::Guard`.  This just pre-declares `Guard::Guard` in the version file and adds it as a parent of `Guard::Sass`.

Only really affects developers using Bundlers local file system development, but shouldn't cause any problems for anyone else.
