### PR TITLE
Explicity add nil to changed_files when there is an error.

### DIFF
--- a/lib/guard/sass.rb
+++ b/lib/guard/sass.rb
@@ -67,6 +67,7 @@ module Guard
         rescue ::Sass::SyntaxError => e
           ::Guard::UI.error "Sass > #{e.sass_backtrace_str(file)}"
           ::Guard::Notifier.notify("rebuild failed > #{e.sass_backtrace_str(file)}", :title => "Guard::Sass", :image => :error) if @options[:notifications]
+          nil
         end
       end.compact
       notify changed_files


### PR DESCRIPTION
This fixes a problem with the notifications on OS X.  It seems Growl returns true when the notification is displayed which doesn't get compacted out of the `changed_files list.

Without this change:

```
ERROR: Sass > Syntax error: "darkblue" is not a color for `darken'
        on line 16 of src/app.css.scss
ERROR: Guard::Sass guard failed to achieve its <run_on_change> command: undefined method `match' for true:TrueClass
Guard Guard::Sass has just been fired
```

With the change:

```
ERROR: Sass > Syntax error: "darkblue" is not a color for `darken'
        on line 16 of src/app.css.scss
```
