### PR TITLE
Guard expects regular expression quoted in slashes or simply in %r{}

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
 guard 'rspec', :version => 2 do
-  watch('^spec/(.*)_spec.rb')
-  watch('^lib/(.*).rb')          { |m| "spec/#{m[1]}_spec.rb" }
-  watch('^spec/spec_helper.rb')  { "spec" }
+  watch(%r{^spec/(.*)_spec.rb})
+  watch(%r{^lib/(.*).rb})          { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^spec/spec_helper.rb})  { "spec" }
 end


### PR DESCRIPTION
When running guard in the project, it complains about regular expressions being quoted.
