### PR TITLE
Improved filename handling

### DIFF
--- a/lib/guard/sass/runner.rb
+++ b/lib/guard/sass/runner.rb
@@ -93,7 +93,7 @@ module Guard
       # @param file [String] Name of the file
       # @return [String] Path of file written
       def write_file(content, dir, file)
-        path = File.join(dir, File.basename(file.split('.')[0])) << '.css'
+        path = File.join(dir, File.basename(file[0..-6]))
       
         unless options[:noop]
           FileUtils.mkdir_p(dir)


### PR DESCRIPTION
Remove .s(a|c)ss from end of filename but leave the rest of the filename intact
