### PR TITLE
Use Sass::Plugin.template_location_array for load_paths

### DIFF
--- a/lib/guard/sass.rb
+++ b/lib/guard/sass.rb
@@ -1,6 +1,7 @@
 require 'guard'
 require 'guard/guard'
 require 'guard/watcher'
+require 'sass/plugin'
 
 module Guard
   class Sass < Guard
@@ -17,7 +18,7 @@ module Guard
       :debug_info   => false,
       :noop         => false,
       :hide_success => false,
-      :load_paths   => Dir.glob('**/**').find_all {|i| File.directory?(i) }
+      :load_paths   => ::Sass::Plugin.template_location_array.map { |dir| dir.first }
     }
 
     # @param watchers [Array<Guard::Watcher>]

--- a/spec/guard/sass_spec.rb
+++ b/spec/guard/sass_spec.rb
@@ -33,7 +33,7 @@ describe Guard::Sass do
           :debug_info   => false,
           :noop         => true,
           :hide_success => true,
-          :load_paths   => Dir.glob('**/**').find_all {|i| File.directory?(i) }
+          :load_paths   => ::Sass::Plugin.template_location_array.map { |dir| dir.first }
         }
       end
     end


### PR DESCRIPTION
Use template locations from SASS instead of globbing all subdirectories
of the current project.

This also enables guard-sass to work with Compass (otherwise `@import
"compass"` does not work because it's outside of the load path).

Also see my original problem with this:
http://stackoverflow.com/questions/10836884/cannot-make-compass-guard-sass-to-work
