### PR TITLE
Fixed typo - added 's' to guard.run_on_change

### DIFF
--- a/lib/guard/sass.rb
+++ b/lib/guard/sass.rb
@@ -161,7 +161,7 @@ module Guard
     def notify(changed_files)
       ::Guard.guards.each do |guard|
         paths = Watcher.match_files(guard, changed_files)
-        guard.run_on_change(paths) unless paths.empty?
+        guard.run_on_changes(paths) unless paths.empty?
       end
     end
 


### PR DESCRIPTION
I'd been getting this error consistently when using this version of guard-sass with the latest guard-livereload:

> [#] NoMethodError: undefined method `run_on_change' for #Guard::LiveReload:0x007fa2e3b45310

Changing this to run_on_changes in sass.rb seems to have fixed it.
