### PR TITLE
Add regex to filter files to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ The following options can be passed to guard-sass:
                                         # A suffix `/(.+\.s[ac]ss)` will be added to this option.
                                         # default: nil
 
+    :filter => /.*/                     # Regexp to filter files to compile.
+                                        # default: `/.*/`
+
     :output => 'stylesheets'            # Relative path to the output directory.
                                         # default: 'css' or the :input option when supplied
 

--- a/lib/guard/sass.rb
+++ b/lib/guard/sass.rb
@@ -10,6 +10,7 @@ module Guard
 
     DEFAULTS = {
       :all_on_start => false,
+      :filter => /.*/,
       :output       => 'css',
       :extension    => '.css',
       :style        => :nested,
@@ -24,6 +25,8 @@ module Guard
     # @param options [Hash]
     # @option options [String] :input
     #   The input directory
+    # @option options [Regexp] :filter
+    #   The Regexp to filter files to compile
     # @option options [String] :output
     #   The output directory
     # @option options [String] :extension
@@ -95,7 +98,7 @@ module Guard
     #
     # @raise [:task_has_failed]
     def run_all
-      run_on_changes files.reject {|f| partial?(f) }
+      run_on_changes files.reject {|f| partial?(f) || !(f =~ options[:filter])}
     end
 
     def resolve_partials_to_owners(paths)


### PR DESCRIPTION
Sometimes we want to watch a whole directory, but only compile some of the files.