### PR TITLE
Add :always_resolve_dependencies flag

### DIFF
--- a/spec/guard/sass/formatter_spec.rb
+++ b/spec/guard/sass/formatter_spec.rb
@@ -5,7 +5,13 @@ describe Guard::Sass::Formatter do
   subject { Guard::Sass::Formatter }
 
   let(:notifier) { Guard::Notifier }
-  let(:ui) { Guard::UI }
+
+  let(:ui) {
+    ::Guard::UI.stub(:error)
+    ::Guard::UI.stub(:info)
+
+    ::Guard::UI
+  }
 
   describe '#success' do
     context 'if success is to be shown' do
@@ -15,9 +21,9 @@ describe Guard::Sass::Formatter do
       end
 
       it 'shows a system notification' do
-        f = subject.new
-        f.should_receive(:notify).with("Yay", :image => :success)
-        f.success("Success message", :notification => "Yay")
+        ui.should_receive(:info).with("\t\e[1;37mSass\e[0m Success message", notification: 'Yay')
+        notifier.should_receive(:notify).with('Yay', title: 'Guard::Sass', image: :success)
+        subject.new.success("Success message", notification: "Yay")
       end
     end
 
@@ -36,9 +42,9 @@ describe Guard::Sass::Formatter do
     end
 
     it 'shows a system notification' do
-      f = subject.new
-      f.should_receive(:notify).with("Boo", :image => :failed)
-      f.error("Error message", :notification => "Boo")
+      ui.should_receive(:error).with('[Sass] Error message', notification: 'Boo')
+      notifier.should_receive(:notify).with('Boo', title: 'Guard::Sass', image: :failed)
+      subject.new.error("Error message", notification: "Boo")
     end
   end
 

--- a/spec/guard/sass/runner_spec.rb
+++ b/spec/guard/sass/runner_spec.rb
@@ -4,8 +4,15 @@ describe Guard::Sass::Runner do
 
   subject { Guard::Sass::Runner }
 
-  let(:watcher)   { Guard::Watcher.new('^(.*)\.s[ac]ss$') }
-  let(:formatter) { Guard::Sass::Formatter.new }
+  let(:watcher)   { Guard::Watcher.new(/^(.*)\.s[ac]ss$/) }
+
+  let(:formatter) {
+    ::Guard::UI.stub(:error)
+    ::Guard::UI.stub(:info)
+
+    Guard::Sass::Formatter.new
+  }
+
   let(:defaults)  { Guard::Sass::DEFAULTS }
 
   before do
@@ -18,7 +25,17 @@ describe Guard::Sass::Runner do
   describe '#run' do
 
     it 'returns a list of changed files' do
-      subject.new([watcher], formatter, defaults).run(['a.sass'])[0].should == ['css/a.css']
+      mock_engine = mock(::Sass::Engine)
+      mock_engine
+        .should_receive(:render)
+
+      ::Sass::Engine
+        .should_receive(:for_file)
+        .and_return(mock_engine)
+
+      subject
+        .new([watcher], formatter, defaults)
+        .run(['a.sass'])[0].should == ['css/a.css']
     end
 
     context 'if errors when compiling' do
@@ -27,24 +44,45 @@ describe Guard::Sass::Runner do
       before do
         $_stderr, $stderr = $stderr, StringIO.new
         IO.stub(:read).and_return('body { color: red;')
+
+        mock_engine = mock(::Sass::Engine)
+        mock_engine
+          .should_receive(:render)
+          .and_raise(Sass::SyntaxError.new('Err'))
+
+        ::Sass::Engine
+          .should_receive(:for_file)
+          .and_return(mock_engine)
       end
 
       after { $stderr = $_stderr }
 
       it 'shows a warning message' do
-        formatter.should_receive(:error).with('Sass > Syntax error: Invalid CSS after "body ": expected selector, was "{ color: red;"
-        on line 1 of a.sass', :notification => 'rebuild of a.sass failed')
+        formatter
+          .should_receive(:error)
+          .with("Sass > Error: Err\n        on line  of a.sass",
+                notification: 'rebuild of a.sass failed')
+
         subject.run(['a.sass'])
       end
 
       it 'returns false' do
         subject.run(['a.sass'])[1].should == false
       end
-
     end
 
     context 'if no errors when compiling' do
       subject { Guard::Sass::Runner.new([watcher], formatter, defaults) }
+
+      before do
+        mock_engine = mock(::Sass::Engine)
+        mock_engine
+          .should_receive(:render)
+
+        ::Sass::Engine
+          .should_receive(:for_file)
+          .and_return(mock_engine)
+      end
 
       it 'shows a success message' do
         formatter.should_receive(:success).with("a.sass -> a.css", instance_of(Hash))
@@ -59,22 +97,25 @@ describe Guard::Sass::Runner do
     it 'compiles the files' do
       Guard::Sass::DEFAULTS[:load_paths] = ['sass']
 
-      mock_engine = mock(::Sass::Engine)
-      ::Sass::Engine.should_receive(:new).with('', {
+      opts = {
         :filesystem_importer => Guard::Sass::Importer,
         :load_paths          => ['sass'],
         :style               => :nested,
         :debug_info          => false,
         :line_numbers        => false,
-        :syntax              => :sass,
-        :filename            => 'a.sass',
         :all_on_start        => false,
         :output              => "css",
         :extension           => ".css",
         :shallow             => false,
         :noop                => false,
         :hide_success        => false
-      }).and_return(mock_engine)
+      }
+
+      mock_engine = mock(::Sass::Engine)
+      ::Sass::Engine
+        .should_receive(:for_file).with('a.sass', opts)
+        .and_return(mock_engine)
+
       mock_engine.should_receive(:render)
 
       subject.new([watcher], formatter, defaults).run(['a.sass'])


### PR DESCRIPTION
Adds the option `:always_resolve_dependencies => true` that will cause guard-sass to resolve dependencies for any files, not just partials.
